### PR TITLE
Update pv move state

### DIFF
--- a/daemons/lvmdbusd/background.py
+++ b/daemons/lvmdbusd/background.py
@@ -11,7 +11,8 @@ import subprocess
 from . import cfg
 from .cmdhandler import options_to_cli_args
 import dbus
-from .utils import pv_range_append, pv_dest_ranges, log_error, log_debug
+from .utils import pv_range_append, pv_dest_ranges, log_error, log_debug,\
+	add_no_notify
 import os
 import threading
 
@@ -42,6 +43,10 @@ def _move_merge(interface_name, command, job_state):
 	# the command always as we will be getting periodic output from them on
 	# the status of the long running operation.
 	command.insert(0, cfg.LVM_CMD)
+
+	# Instruct lvm to not register an event with us
+	command = add_no_notify(command)
+
 	process = subprocess.Popen(command, stdout=subprocess.PIPE,
 								env=os.environ,
 								stderr=subprocess.PIPE, close_fds=True)

--- a/daemons/lvmdbusd/background.py
+++ b/daemons/lvmdbusd/background.py
@@ -64,6 +64,10 @@ def _move_merge(interface_name, command, job_state):
 				(device, ignore, percentage) = line_str.split(':')
 				job_state.Percent = round(
 					float(percentage.strip()[:-1]), 1)
+
+				# While the move is in progress we need to periodically update
+				# the state to reflect where everything is at.
+				cfg.load()
 		except ValueError:
 			log_error("Trying to parse percentage which failed for %s" %
 				line_str)

--- a/daemons/lvmdbusd/cfg.py
+++ b/daemons/lvmdbusd/cfg.py
@@ -26,7 +26,7 @@ bus = None
 args = None
 
 # Set to true if we are depending on external events for updates
-ee = False
+got_external_event = False
 
 # Shared state variable across all processes
 run = multiprocessing.Value('i', 1)

--- a/daemons/lvmdbusd/manager.py
+++ b/daemons/lvmdbusd/manager.py
@@ -206,7 +206,7 @@ class Manager(AutomatedProperties):
 				utils.log_debug("ExternalEvent received, disabling "
 								"udev monitoring")
 				# We are dependent on external events now to stay current!
-				cfg.ee = True
+				cfg.got_external_event = True
 
 		r = RequestEntry(
 			-1, Manager._external_event, (command,), None, None, False)

--- a/daemons/lvmdbusd/utils.py
+++ b/daemons/lvmdbusd/utils.py
@@ -512,7 +512,7 @@ def add_no_notify(cmdline):
 
 	# Only after we have seen an external event will be disable lvm from sending
 	# us one when we call lvm
-	if cfg.ee:
+	if cfg.got_external_event:
 		if 'help' in cmdline:
 			return cmdline
 

--- a/daemons/lvmdbusd/utils.py
+++ b/daemons/lvmdbusd/utils.py
@@ -510,16 +510,19 @@ def add_no_notify(cmdline):
 	:rtype: list
 	"""
 
-	if 'help' in cmdline:
-		return cmdline
+	# Only after we have seen an external event will be disable lvm from sending
+	# us one when we call lvm
+	if cfg.ee:
+		if 'help' in cmdline:
+			return cmdline
 
-	if '--config' in cmdline:
-		for i, arg in enumerate(cmdline):
-			if arg == '--config':
-				cmdline[i] += "global/notify_dbus=0"
-				break
-	else:
-		cmdline.extend(['--config', 'global/notify_dbus=0'])
+		if '--config' in cmdline:
+			for i, arg in enumerate(cmdline):
+				if arg == '--config':
+					cmdline[i] += "global/notify_dbus=0"
+					break
+		else:
+			cmdline.extend(['--config', 'global/notify_dbus=0'])
 	return cmdline
 
 


### PR DESCRIPTION
Ensure that the dbus objects have a fairly accurate representation of the state when a move is in progress.