### PR TITLE
Lvmdbusd stall

### DIFF
--- a/daemons/lvmdbusd/pv.py
+++ b/daemons/lvmdbusd/pv.py
@@ -79,7 +79,9 @@ class PvState(State):
 
 		self.lv = self._lv_object_list(vg_name)
 
-		if vg_name:
+		# It's possible to have a vg_name and no uuid with the main example
+		# being when the vg_name == '[unknown]'
+		if vg_uuid and vg_name:
 			self.vg_path = cfg.om.get_object_path_by_uuid_lvm_id(
 				vg_uuid, vg_name, vg_obj_path_generate)
 		else:

--- a/daemons/lvmdbusd/utils.py
+++ b/daemons/lvmdbusd/utils.py
@@ -584,7 +584,7 @@ class MThreadRunner(object):
 
 	def _run(self):
 		try:
-			if len(self.args):
+			if self.args:
 				self.rc = self.f(*self.args)
 			else:
 				self.rc = self.f()


### PR DESCRIPTION
This change addresses two things:

1. Why we weren't getting any debug data when an exception occurred which made this very difficult to correct, but catching and reporting this and finishing the remaining clean-up we no longer stall the calling thread.

2. The bug which was causing the the exception.