### PR TITLE
Lvmdbusd corrections

### DIFF
--- a/daemons/lvmdbusd/cmdhandler.py
+++ b/daemons/lvmdbusd/cmdhandler.py
@@ -67,7 +67,7 @@ class LvmFlightRecorder(object):
 		with cmd_lock:
 			if len(self.queue):
 				log_error("LVM dbus flight recorder START")
-				for c in self.queue:
+				for c in reversed(self.queue):
 					log_error(str(c))
 				log_error("LVM dbus flight recorder END")
 

--- a/daemons/lvmdbusd/lv.py
+++ b/daemons/lvmdbusd/lv.py
@@ -346,13 +346,19 @@ class LvCommon(AutomatedProperties):
 
 	@property
 	def State(self):
-		type_map = {'a': 'active', 's': 'suspended', 'I': 'Invalid snapshot',
+		type_map = {'a': 'active',
+					's': 'suspended',
+					'I': 'Invalid snapshot',
 					'S': 'invalid Suspended snapshot',
 					'm': 'snapshot merge failed',
 					'M': 'suspended snapshot (M)erge failed',
 					'd': 'mapped device present without  tables',
 					'i': 'mapped device present with inactive table',
-					'X': 'unknown', '-': 'Unspecified'}
+					'h': 'historical',
+					'c': 'check needed suspended thin-pool',
+					'C': 'check needed',
+					'X': 'unknown',
+					'-': 'Unspecified'}
 		return self.attr_struct(4, type_map)
 
 	@property

--- a/daemons/lvmdbusd/lv.py
+++ b/daemons/lvmdbusd/lv.py
@@ -369,9 +369,17 @@ class LvCommon(AutomatedProperties):
 
 	@property
 	def Health(self):
-		type_map = {'p': 'partial', 'r': 'refresh',
-					'm': 'mismatches', 'w': 'writemostly',
-					'X': 'X unknown', '-': 'Unspecified'}
+		type_map = {'p': 'partial',
+					'r': 'refresh needed',
+					'm': 'mismatches',
+					'w': 'writemostly',
+					'X': 'unknown',
+					'-': 'unspecified',
+					's': 'reshaping',
+					'F': 'failed',
+					'D': 'Data space',
+					'R': 'Remove',
+					'M': 'Metadata'}
 		return self.attr_struct(8, type_map)
 
 	@property


### PR DESCRIPTION
Collection of small fixes:

* Reverse the order of flight recorder when dumped
* Guard against lv_attr bits which we don't know about
* Update translation tables for lv_attr bits