### PR TITLE
Wipefs correction

### DIFF
--- a/daemons/lvmdbusd/main.py
+++ b/daemons/lvmdbusd/main.py
@@ -125,7 +125,8 @@ def process_args():
 	# Add udev watching
 	if args.use_udev:
 		# Make sure this msg ends up in the journal, so we know
-		log_msg('Utilizing udev to trigger updates')
+		log_msg('The --udev option is no longer supported,'
+				'the daemon always uses a combination of dbus notify from lvm tools and udev')
 
 	return args
 

--- a/daemons/lvmdbusd/manager.py
+++ b/daemons/lvmdbusd/manager.py
@@ -203,12 +203,6 @@ class Manager(AutomatedProperties):
 		in_signature='s', out_signature='i')
 	def ExternalEvent(self, command):
 		utils.log_debug("ExternalEvent %s" % command)
-		# If a user didn't explicitly specify udev, we will turn it off now.
-		if not cfg.args.use_udev:
-			if udevwatch.remove():
-				utils.log_msg("ExternalEvent received, disabling "
-								"udev monitoring")
-				# We are dependent on external events now to stay current!
 		r = RequestEntry(
 			-1, Manager._external_event, (command,), None, None, False)
 		cfg.worker_q.put(r)


### PR DESCRIPTION
Fix for external program issuing `wipefs -a <lvm pv>`

**Note: In testing we have observed cases where it takes  ~200ms for the udev event to get delivered and processed fully by lvm dbusd.  Thus clients manually wiping a block device and then instantly turning around and calling into lvm dbus service to create a PV could get an error because of this race condition**