### PR TITLE
Circle CI demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+jobs:
+  build:
+    machine:
+      image: ubuntu-2204:2023.04.2
+    steps:
+      - checkout
+      - run:
+          name: "Test lvmdbusd"
+          command: sudo test/dbus/debian_ci.sh
+      - store_artifacts:
+          path: /tmp/lvmdbusd.out.txt

--- a/test/dbus/debian_ci.sh
+++ b/test/dbus/debian_ci.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+# Run unit tests for lvmdbusd on ubuntu/debian
+
+export DEBIAN_FRONTEND="noninteractive"
+apt-get update -y -q || exit 1
+
+# install dependencies
+apt-get install debhelper-compat autoconf-archive automake libaio-dev libblkid-dev pkg-config systemd \
+	thin-provisioning-tools python3-dbus python3-dev python3-pyudev libcmap-dev libcorosync-common-dev \
+	libcpg-dev  libdlm-dev libdlmcontrol-dev  libedit-dev libquorum-dev  libsanlock-dev  libselinux1-dev \
+	libsystemd-dev  libudev-dev -y -q || exit 1
+
+./configure --enable-dbus-service --enable-notify-dbus --enable-editline || exit 1
+
+make -j12 || exit 1
+
+export LVM_BINARY=`pwd`/tools/lvm
+export PYTHONPATH=`pwd`/daemons
+
+cp ./scripts/com.redhat.lvmdbus1.conf /etc/dbus-1/system.d/. || exit 1
+
+truncate -s 1T /d1.disk || exit 1
+truncate -s 1T /d2.disk || exit 1
+truncate -s 1T /d3.disk || exit 1
+
+dev1=`losetup -f --show /d1.disk`
+$LVM_BINARY pvcreate $dev1 || exit 1
+
+dev2=`losetup -f --show /d2.disk`
+$LVM_BINARY pvcreate $dev2 || exit 1
+
+dev3=`losetup -f --show /d3.disk`
+$LVM_BINARY pvcreate $dev3 || exit 1
+
+python3 daemons/lvmdbusd/lvmdbusd 2>&1 >> /tmp/lvmdbusd.out.txt &
+
+sleep 10
+
+test/dbus/lvmdbustest.py -v || { echo /tmp/lvmdbusd.out ; exit 1;}

--- a/test/dbus/debian_ci.sh
+++ b/test/dbus/debian_ci.sh
@@ -2,6 +2,10 @@
 
 # Run unit tests for lvmdbusd on ubuntu/debian
 
+echo "-------"
+lsb_release -a
+echo "-------"
+
 export DEBIAN_FRONTEND="noninteractive"
 apt-get update -y -q || exit 1
 
@@ -11,7 +15,10 @@ apt-get install debhelper-compat autoconf-archive automake libaio-dev libblkid-d
 	libcpg-dev  libdlm-dev libdlmcontrol-dev  libedit-dev libquorum-dev  libsanlock-dev  libselinux1-dev \
 	libsystemd-dev  libudev-dev -y -q || exit 1
 
-./configure --enable-dbus-service --enable-notify-dbus --enable-editline || exit 1
+./configure --enable-udev_sync --with-device-uid=0 --with-device-gid=6 --with-device-mode=0660 \
+	--enable-pkgconfig -enable-cmdlib --enable-dbus-service --enable-notify-dbus --enable-editline \
+	--with-thin=internal --with-cache=internal 	|| exit 1
+
 
 make -j12 || exit 1
 
@@ -37,4 +44,5 @@ python3 daemons/lvmdbusd/lvmdbusd 2>&1 >> /tmp/lvmdbusd.out.txt &
 
 sleep 10
 
-test/dbus/lvmdbustest.py -v || { echo /tmp/lvmdbusd.out ; exit 1;}
+#test/dbus/lvmdbustest.py -v -f TestDbusService.test_cache_lv_rename || { echo "Unit test failed, check artifacts" ; exit 1;}
+test/dbus/lvmdbustest.py -v -f || { echo "Unit test failed, check artifacts" ; exit 1;}

--- a/test/dbus/lvmdbustest.py
+++ b/test/dbus/lvmdbustest.py
@@ -2069,7 +2069,7 @@ class TestDbusService(unittest.TestCase):
 
 	@staticmethod
 	def _scan_lvs_enabled():
-		cmd = ['lvmconfig',  '--typeconfig', 'full', 'devices/scan_lvs']
+		cmd = [LVM_EXECUTABLE, 'lvmconfig',  '--typeconfig', 'full', 'devices/scan_lvs']
 		config = Popen(cmd, stdout=PIPE, stderr=PIPE, close_fds=True, env=os.environ)
 		out = config.communicate()
 		if config.returncode != 0:
@@ -2116,6 +2116,9 @@ class TestDbusService(unittest.TestCase):
 
 		if not pv_device_path.startswith("/dev"):
 			raise unittest.SkipTest('test not running in /dev')
+
+		if  pv_device_path.startswith("/dev/loop"):
+			raise unittest.SkipTest('not running test against loopback devices')
 
 		self._pv_remove(pv)
 


### PR DESCRIPTION
Circle CI example which shows what is needed to leverage their VM support.  This demo only runs the lvmdbusd unit tests. 

The pieces that are important
1. The circle CI configuration located in `.circleci/config.yaml`
2. . A test script that configures the environment, configures and builds LVM, starts the lvmdbusd daemon and runs the unit test, located `test/dbus/debian_ci.sh`
3. The exit code of the test script determines if the unit test is successful or not, `0 == success`

```yaml
version: 2.1
jobs:
  build:
    machine:
      image: ubuntu-2204:2023.04.2
    steps:
      - checkout
      - run:
          name: "Test lvmdbusd"
          command: sudo test/dbus/debian_ci.sh
      - store_artifacts:
          path: /tmp/lvmdbusd.out.txt
```